### PR TITLE
Variable only gets queried once per paste

### DIFF
--- a/plugin/vim-crosspaste.vim
+++ b/plugin/vim-crosspaste.vim
@@ -1,6 +1,6 @@
 " Title: vim-crosspaste plugin
 " Description: Works with Vimux to paste text across vimux panes
-" Last Change: 13 June 2022
+" Last Change: 19 October 2022
 " Maintainer: Sam Jones <sjones6@paypal.com>
 
 if exists("g:CrossPasteLoaded")
@@ -21,30 +21,35 @@ else
     call VimuxRunCommand(@q)
   endfunction
 
-  function! SwitchMatch(input)
+  function! SwitchMatch(input, entered)
     let l:start = match(a:input, "\$\{[^}]*\}")
     let l:end = matchend(a:input, "^[^\$]*\$\{[^}]*\}")
     let l:variable = strpart(a:input, l:start+2, l:end - l:start - 3)
-    return strpart(a:input, 0, l:start) . UserValue(variable) . strpart(a:input, l:end)
+    return strpart(a:input, 0, l:start) . UserValue(variable, a:entered) . strpart(a:input, l:end)
   endfunction
 
   function! AllValues(input)
     let l:process = a:input
+    let l:entered = []
     while match(l:process, "\$\{[^}]*\}") >= 0
-      let l:process = SwitchMatch(l:process)
+      let l:process = SwitchMatch(l:process, l:entered)
     endwhile
     return l:process
   endfunction
 
-  function! UserValue(userinput)
+  function! UserValue(userinput, entered)
     let l:default = ''
     if has_key(g:CrossPasteList, a:userinput)
       let l:default = g:CrossPasteList[a:userinput]
+      if index(a:entered, a:userinput) > -1
+        return l:default
+      endif
     endif
     call inputsave()
     let l:uservalue = input('Enter ' . a:userinput . ': ', l:default)
     call inputrestore()
     let g:CrossPasteList[a:userinput] = l:uservalue
+    call add(a:entered, a:userinput)
     return l:uservalue
   endfunction
 endif


### PR DESCRIPTION
I added a check so that if a single variable only gets queried once. Previously, if you had five instances of ${primary_key} in your block, you'd have to type in a value for "primary_key:" five times. Now, it'll only ask once per block, though it'll ask again the next time you cross paste that block.